### PR TITLE
Geofence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/*
+Data/*
+BIKE.CFG

--- a/BIKE.CFG.example
+++ b/BIKE.CFG.example
@@ -8,6 +8,9 @@ PSK=superSafePassword2021
 # DEFLON und DEFLAT ist die koordiante, die gesetzt wird, wenn Koordinaten in der Homzone sind.
 # HOME_MINLON=13.3xxxx
 # HOME_MINLAT=52.5xxxx
+# Zb im Sprengelkiez der Sprengelpark: https://goo.gl/maps/3gHGRP1JbH2wfFHS8
+# HOME_DEFLON=13.353277
+# HOME_DEFLAT=52.540779
 HOME_MINLON=
 HOME_MAXLON=
 HOME_MINLAT=

--- a/BIKE.CFG.example
+++ b/BIKE.CFG.example
@@ -1,0 +1,20 @@
+# WLAN Configuration
+SSID=MyNetwork
+PSK=superSafePassword2021
+
+# Sensor IDs können über die API abgefragt werden 
+# https://api.opensensemap.org/boxes/[:senseBoxID]
+# senseboxIds
+# Example SENSEBOX_ID=615f292bc031ff001b117192
+#         TEMP_ID=615f292bc031ff001b11719b
+SENSEBOX_ID=
+TEMP_ID=
+HUMI_ID=
+DIST_L_ID=
+DIST_R_ID=
+PM10_ID=
+PM25_ID=
+ACC_X_ID=
+ACC_Y_ID=
+ACC_Z_ID=
+SPEED_ID=

--- a/BIKE.CFG.example
+++ b/BIKE.CFG.example
@@ -2,6 +2,19 @@
 SSID=MyNetwork
 PSK=superSafePassword2021
 
+# Donottrack Area
+# https://www.openstreetmap.org/export
+# Hier kann man sich ein Rechteck generieren, das nicht auf Opensensemap hochgeladen werden soll. 
+# DEFLON und DEFLAT ist die koordiante, die gesetzt wird, wenn Koordinaten in der Homzone sind.
+# HOME_MINLON=13.3xxxx
+# HOME_MINLAT=52.5xxxx
+HOME_MINLON=
+HOME_MAXLON=
+HOME_MINLAT=
+HOME_MAXLAT=
+HOME_DEFLON=
+HOME_DEFLAT=
+
 # Sensor IDs können über die API abgefragt werden 
 # https://api.opensensemap.org/boxes/[:senseBoxID]
 # senseboxIds

--- a/GPShelpers.ino
+++ b/GPShelpers.ino
@@ -1,3 +1,5 @@
+#include "variables/variables.h"
+
 void initGPS()
 {
   Wire.begin();
@@ -47,9 +49,23 @@ void setGPS(){
   float longitude = myGNSS.getLongitude() / (float)10000000;
   char lng[20];
   char lat[20];
-  dtostrf(longitude, 2, 7, lng);
-  dtostrf(latitude, 1, 7, lat);
-    
+  double homeLon[] = {minLon, minLon, maxLon, maxLon};
+  double homeLat[] = {minLat, maxLat, maxLat, minLat};
+
+  // set GPS to fixed position, when the actual position is inside the fence.
+  if (defLat > 1 && defLon > 1) { // check if default coordiante is set.
+    if (pnpoly(4, homeLat, homeLon, latitude, longitude)) {
+      dtostrf(defLon, 2, 7, lng);
+      dtostrf(defLat, 1, 7, lat);
+    } else {
+      dtostrf(longitude, 2, 7, lng);
+      dtostrf(latitude, 1, 7, lat);
+    }
+  } else {
+      dtostrf(longitude, 2, 7, lng);
+      dtostrf(latitude, 1, 7, lat);
+  }
+
     
   strcpy_P(lngGlobal, lng);
   strcpy_P(latGlobal, lat);

--- a/HCSR04Helpers.ino
+++ b/HCSR04Helpers.ino
@@ -1,3 +1,4 @@
+#include "variables/variables.h"
 void initUltrasonic()
 {
   //pinmodes for ultrasonic

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Mit Hilfe der [openSenseMapAPI](https://api.opensensemap.org/) kannst du die Sen
 
 Alternativ kann auf der SDCard eine Datei `BIKE.CFG` (Siehe `BIKE.CFG.example`) angelegt werden, die die Variablen Datenschutzfreundlich initialisiert.
 
+In der `BIKE.CFG` kann auch ein umgekehrte [Geofencing](https://de.wikipedia.org/wiki/Geofencing) eingrichtet werden. Dort kann man seine Heimatadresse 'verstecken'. Wenn Koordinaten in dem definiertem Rechteck erfasst werden, werden sie auf eine festgelegte Koordinate (z.B. ein Park) umgeschrieben. 
+
 ## Upload
 - Mit Hilfe der Arduino IDE auf die senseBox hochladen
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ Mobile Messstation mit der Temperatur, rel. Luftfeuchte, Feinstaub (PM10, PM25),
   - [NewPing](https://www.arduino.cc/reference/en/libraries/newping "NewPing")
   - [SparkFun u-Blox GNSS](https://www.arduino.cc/reference/en/libraries/sparkfun-u-blox-gnss-arduino-library/ "SparkFun u-Blox GNSS")
   - [BMX](https://github.com/sensebox/BMX)
+  - [SD](https://www.arduino.cc/en/Reference/SD "SD") For Linux systems
+  - [SDConfig](https://github.com/Fuzzer11/SDconfig)
   
 ## Credentials hinzufügen 
 Mit Hilfe der [openSenseMapAPI](https://api.opensensemap.org/) kannst du die Sensor IDs deiner Box abfragen. Der API call lautet `https://api.opensensemap.org/boxes/[:senseBoxID]`.
  - In der Datei `variables/network.h` WiFi Informationen (SSID und Passwort) eingeben 
  - In der Datei `variables/ids.h` senseBox ID und Sensor ID's von der openSenseMap eintragen 
+
+Alternativ kann auf der SDCard eine Datei `BIKE.CFG` (Siehe `BIKE.CFG.example`) angelegt werden, die die Variablen Datenschutzfreundlich initialisiert.
 
 ## Upload
 - Mit Hilfe der Arduino IDE auf die senseBox hochladen
@@ -36,4 +40,3 @@ Mit Hilfe der [openSenseMapAPI](https://api.opensensemap.org/) kannst du die Sen
 
 - In `futuriumSDNoAP.ino` das Makro `#define DEBUG_ENABLED` setzen, damit DEBUG Nachrichten in der seriellen Konsole angezeigt werden.
 - ⚠️ **ACHTUNG** Im DEBUG Modus startet die Box erst, wenn der *Serielle Monitor* geöffnet wird. Vor dem Betrieb den DEBUG Modus IMMER ausschalten!
-

--- a/SDhelpers.ino
+++ b/SDhelpers.ino
@@ -1,3 +1,4 @@
+#include "variables/variables.h"
 void writeToSD(char *data, char *fileName)
 {
   myFile = SD.open(fileName, FILE_WRITE);
@@ -35,10 +36,13 @@ void resetSD()
 
 bool sdisempty() {
   bool empty = true;
-
+Serial.print("SDisempty ");
   for (int i = 0; i < 3; i++) {
     if (SD.exists(fileNames[i])) {
       empty = false;
+#ifdef DEBUG_ENABLED
+     Serial.println(" false");
+#endif
     }
   }
   return empty;
@@ -81,4 +85,137 @@ void checkForFiles()
       myFile.close();
     }
   }
+}
+
+boolean readConfiguration( char* configFile )
+{
+  /*
+   * Length of the longest line expected in the config file.
+   * The larger this number, the more memory is used
+   * to read the file.
+   * You probably won't need to change this number.
+   */
+  int maxLineLength = 127;
+  SDConfig cfg;
+  
+  // Open the configuration file.
+  if (!cfg.begin(configFile, maxLineLength)) {
+#ifdef DEBUG_ENABLED
+    Serial.print(" Failed to open configuration file: ");
+    Serial.println(configFile);
+#endif
+    return false;
+  }
+
+  // Read each setting from the file.
+  while (cfg.readNextSetting()) {
+    // Put a nameIs() block here for each setting you have.
+    // ssid
+    if (cfg.nameIs("SSID")) {
+      ssid = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read SSID: ");
+      Serial.println(ssid);
+#endif      
+    } else if (cfg.nameIs("PSK")) {
+      pass = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read PSK: ");
+      Serial.println(pass);
+#endif      
+    } else if (cfg.nameIs("SENSEBOX_ID")) {
+      SENSEBOX_ID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read SENSEBOX_ID: ");
+      Serial.println(SENSEBOX_ID);
+#endif      
+    } else if (cfg.nameIs("TEMP_ID")) {
+      tempID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read TEMP_ID: ");
+      Serial.println(tempID);
+#endif      
+    } else if (cfg.nameIs("HUMI_ID")) {
+      humiID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read HUMI_ID: ");
+      Serial.println(humiID);
+#endif      
+    } else if (cfg.nameIs("DIST_L_ID")) {
+      distLeftID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read DIST_L_ID: ");
+      Serial.println(distLeftID);
+#endif      
+    } else if (cfg.nameIs("DIST_R_ID")) {
+      distRightID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read DIST_R_ID: ");
+      Serial.println(distRightID);
+#endif      
+    } else if (cfg.nameIs("PM10_ID")) {
+      pm10ID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read PM10_ID: ");
+      Serial.println(pm10ID);
+#endif      
+    } else if (cfg.nameIs("PM25_ID")) {
+      pm25ID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read PM25_ID: ");
+      Serial.println(pm25ID);
+#endif      
+    } else if (cfg.nameIs("ACC_X_ID")) {
+      accXID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read ACC_X_ID: ");
+      Serial.println(accXID);
+#endif      
+    } else if (cfg.nameIs("ACC_Y_ID")) {
+      accYID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read ACC_Y_ID: ");
+      Serial.println(accYID);
+#endif      
+    } else if (cfg.nameIs("ACC_Z_ID")) {
+      accZID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read ACC_Z_ID: ");
+      Serial.println(accZID);
+#endif      
+    } else if (cfg.nameIs("SPEED_ID")) {
+      speedID = cfg.copyValue();
+#ifdef DEBUG_ENABLED
+      Serial.print("Read SPEED_ID: ");
+      Serial.println(speedID);
+#endif      
+    } else {
+      // report unrecognized names.
+#ifdef DEBUG_ENABLED
+      Serial.print("Unknown name in config: ");
+      Serial.println(cfg.getName());
+#endif
+    }
+  }
+  // clean up
+  cfg.end();
+  return true;
+}
+
+void dumpConfiguration()
+{
+  Serial.println("Current Config");
+  Serial.print("SSID:        "); Serial.println(ssid);
+  Serial.print("PSK:         "); Serial.println(pass );
+  Serial.print("SENSEBOX_ID: "); Serial.println(SENSEBOX_ID);
+  Serial.print("TEMP_ID:     "); Serial.println(tempID);
+  Serial.print("HUMI_ID:     "); Serial.println(humiID);
+  Serial.print("DIST_L_ID:   "); Serial.println(distLeftID);
+  Serial.print("DIST_R_ID:   "); Serial.println(distRightID);
+  Serial.print("PM10_ID:     "); Serial.println(pm10ID);
+  Serial.print("PM25_ID:     "); Serial.println(pm25ID);
+  Serial.print("ACC_X_ID:    "); Serial.println(accXID);
+  Serial.print("ACC_Y_ID:    "); Serial.println(accYID);
+  Serial.print("ACC_Z_ID:    "); Serial.println(accZID);
+  Serial.print("SPEED_ID:    "); Serial.println(speedID);
 }

--- a/SDhelpers.ino
+++ b/SDhelpers.ino
@@ -37,13 +37,10 @@ void resetSD()
 
 bool sdisempty() {
   bool empty = true;
-Serial.print("SDisempty ");
+
   for (int i = 0; i < 3; i++) {
     if (SD.exists(fileNames[i])) {
       empty = false;
-#ifdef DEBUG_ENABLED
-     Serial.println(" false");
-#endif
     }
   }
   return empty;

--- a/SDhelpers.ino
+++ b/SDhelpers.ino
@@ -178,34 +178,34 @@ boolean readConfiguration( char* configFile )
       Serial.print("Read SPEED_ID: "); Serial.println(speedID);
 #endif      
     } else if (cfg.nameIs("HOME_MINLON")) {
-      minLon = atof(cfg.copyValue());
+      minLon = strtod(cfg.copyValue(), NULL);
 #ifdef DEBUG_ENABLED
-      Serial.print("Read HOME_MINLON: "); Serial.println(minLon);
+      Serial.print("Read HOME_MINLON: "); Serial.println(minLon, 7);
 #endif      
     } else if (cfg.nameIs("HOME_MAXLON")) {
-      maxLon = atof(cfg.copyValue());
+      maxLon = strtod(cfg.copyValue(), NULL);
 #ifdef DEBUG_ENABLED
-      Serial.print("Read HOME_MAXLON: "); Serial.println(maxLon);
+      Serial.print("Read HOME_MAXLON: "); Serial.println(maxLon, 7);
 #endif      
     } else if (cfg.nameIs("HOME_MINLAT")) {
-      minLat = atof(cfg.copyValue());
+      minLat = strtod(cfg.copyValue(), NULL);
 #ifdef DEBUG_ENABLED
-      Serial.print("Read HOME_MINLAT: "); Serial.println(minLat);
+      Serial.print("Read HOME_MINLAT: "); Serial.println(minLat, 7);
 #endif      
     } else if (cfg.nameIs("HOME_MAXLAT")) {
-      maxLat = atof(cfg.copyValue());
+      maxLat = strtod(cfg.copyValue(), NULL);
 #ifdef DEBUG_ENABLED
-      Serial.print("Read HOME_MAXLAT: "); Serial.println(maxLat);
+      Serial.print("Read HOME_MAXLAT: "); Serial.println(maxLat, 7);
 #endif      
     } else if (cfg.nameIs("HOME_DEFLAT")) {
-      defLat = atof(cfg.copyValue());
+      defLat = strtod(cfg.copyValue(), NULL);
 #ifdef DEBUG_ENABLED
-      Serial.print("Read HOME_DEFLAT: "); Serial.println(defLat);
+      Serial.print("Read HOME_DEFLAT: "); Serial.println(defLat, 7);
 #endif      
     } else if (cfg.nameIs("HOME_DEFLON")) {
-      defLon = atof(cfg.copyValue());
+      defLon = strtod(cfg.copyValue(), NULL);
 #ifdef DEBUG_ENABLED
-      Serial.print("Read HOME_DEFLON: "); Serial.println(defLon);
+      Serial.print("Read HOME_DEFLON: "); Serial.println(defLon, 7);
 #endif      
 
     } else {
@@ -237,10 +237,10 @@ void dumpConfiguration()
   Serial.print("ACC_Y_ID:    "); Serial.println(accYID);
   Serial.print("ACC_Z_ID:    "); Serial.println(accZID);
   Serial.print("SPEED_ID:    "); Serial.println(speedID);
-  Serial.print("HOME_MINLON: "); Serial.println(minLon);
-  Serial.print("HOME_MAXLON: "); Serial.println(maxLon);
-  Serial.print("HOME_MAXLAT: "); Serial.println(minLat);
-  Serial.print("HOME_MINLAT: "); Serial.println(maxLat);
-  Serial.print("HOME_DEFLON: "); Serial.println(defLon);
-  Serial.print("HOME_DEFLAT: "); Serial.println(defLat);
+  Serial.print("HOME_MINLON: "); Serial.println(minLon, 7);
+  Serial.print("HOME_MAXLON: "); Serial.println(maxLon, 7);
+  Serial.print("HOME_MAXLAT: "); Serial.println(minLat, 7);
+  Serial.print("HOME_MINLAT: "); Serial.println(maxLat, 7);
+  Serial.print("HOME_DEFLON: "); Serial.println(defLon, 7);
+  Serial.print("HOME_DEFLAT: "); Serial.println(defLat, 7);
 }

--- a/SDhelpers.ino
+++ b/SDhelpers.ino
@@ -1,4 +1,5 @@
 #include "variables/variables.h"
+
 void writeToSD(char *data, char *fileName)
 {
   myFile = SD.open(fileName, FILE_WRITE);
@@ -114,81 +115,99 @@ boolean readConfiguration( char* configFile )
     if (cfg.nameIs("SSID")) {
       ssid = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read SSID: ");
-      Serial.println(ssid);
+      Serial.print("Read SSID: "); Serial.println(ssid);
 #endif      
     } else if (cfg.nameIs("PSK")) {
       pass = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read PSK: ");
-      Serial.println(pass);
+      Serial.print("Read PSK: "); Serial.println(pass);
 #endif      
     } else if (cfg.nameIs("SENSEBOX_ID")) {
       SENSEBOX_ID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read SENSEBOX_ID: ");
-      Serial.println(SENSEBOX_ID);
+      Serial.print("Read SENSEBOX_ID: "); Serial.println(SENSEBOX_ID);
 #endif      
     } else if (cfg.nameIs("TEMP_ID")) {
       tempID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read TEMP_ID: ");
-      Serial.println(tempID);
+      Serial.print("Read TEMP_ID: "); Serial.println(tempID);
 #endif      
     } else if (cfg.nameIs("HUMI_ID")) {
       humiID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read HUMI_ID: ");
-      Serial.println(humiID);
+      Serial.print("Read HUMI_ID: "); Serial.println(humiID);
 #endif      
     } else if (cfg.nameIs("DIST_L_ID")) {
       distLeftID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read DIST_L_ID: ");
-      Serial.println(distLeftID);
+      Serial.print("Read DIST_L_ID: "); Serial.println(distLeftID);
 #endif      
     } else if (cfg.nameIs("DIST_R_ID")) {
       distRightID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read DIST_R_ID: ");
-      Serial.println(distRightID);
+      Serial.print("Read DIST_R_ID: "); Serial.println(distRightID);
 #endif      
     } else if (cfg.nameIs("PM10_ID")) {
       pm10ID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read PM10_ID: ");
-      Serial.println(pm10ID);
+      Serial.print("Read PM10_ID: "); Serial.println(pm10ID);
 #endif      
     } else if (cfg.nameIs("PM25_ID")) {
       pm25ID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read PM25_ID: ");
-      Serial.println(pm25ID);
+      Serial.print("Read PM25_ID: "); Serial.println(pm25ID);
 #endif      
     } else if (cfg.nameIs("ACC_X_ID")) {
       accXID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read ACC_X_ID: ");
-      Serial.println(accXID);
+      Serial.print("Read ACC_X_ID: "); Serial.println(accXID);
 #endif      
     } else if (cfg.nameIs("ACC_Y_ID")) {
       accYID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read ACC_Y_ID: ");
-      Serial.println(accYID);
+      Serial.print("Read ACC_Y_ID: "); Serial.println(accYID);
 #endif      
     } else if (cfg.nameIs("ACC_Z_ID")) {
       accZID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read ACC_Z_ID: ");
-      Serial.println(accZID);
+      Serial.print("Read ACC_Z_ID: "); Serial.println(accZID);
 #endif      
     } else if (cfg.nameIs("SPEED_ID")) {
       speedID = cfg.copyValue();
 #ifdef DEBUG_ENABLED
-      Serial.print("Read SPEED_ID: ");
-      Serial.println(speedID);
+      Serial.print("Read SPEED_ID: "); Serial.println(speedID);
 #endif      
+    } else if (cfg.nameIs("HOME_MINLON")) {
+      minLon = atof(cfg.copyValue());
+#ifdef DEBUG_ENABLED
+      Serial.print("Read HOME_MINLON: "); Serial.println(minLon);
+#endif      
+    } else if (cfg.nameIs("HOME_MAXLON")) {
+      maxLon = atof(cfg.copyValue());
+#ifdef DEBUG_ENABLED
+      Serial.print("Read HOME_MAXLON: "); Serial.println(maxLon);
+#endif      
+    } else if (cfg.nameIs("HOME_MINLAT")) {
+      minLat = atof(cfg.copyValue());
+#ifdef DEBUG_ENABLED
+      Serial.print("Read HOME_MINLAT: "); Serial.println(minLat);
+#endif      
+    } else if (cfg.nameIs("HOME_MAXLAT")) {
+      maxLat = atof(cfg.copyValue());
+#ifdef DEBUG_ENABLED
+      Serial.print("Read HOME_MAXLAT: "); Serial.println(maxLat);
+#endif      
+    } else if (cfg.nameIs("HOME_DEFLAT")) {
+      defLat = atof(cfg.copyValue());
+#ifdef DEBUG_ENABLED
+      Serial.print("Read HOME_DEFLAT: "); Serial.println(defLat);
+#endif      
+    } else if (cfg.nameIs("HOME_DEFLON")) {
+      defLon = atof(cfg.copyValue());
+#ifdef DEBUG_ENABLED
+      Serial.print("Read HOME_DEFLON: "); Serial.println(defLon);
+#endif      
+
     } else {
       // report unrecognized names.
 #ifdef DEBUG_ENABLED
@@ -218,4 +237,10 @@ void dumpConfiguration()
   Serial.print("ACC_Y_ID:    "); Serial.println(accYID);
   Serial.print("ACC_Z_ID:    "); Serial.println(accZID);
   Serial.print("SPEED_ID:    "); Serial.println(speedID);
+  Serial.print("HOME_MINLON: "); Serial.println(minLon);
+  Serial.print("HOME_MAXLON: "); Serial.println(maxLon);
+  Serial.print("HOME_MAXLAT: "); Serial.println(minLat);
+  Serial.print("HOME_MINLAT: "); Serial.println(maxLat);
+  Serial.print("HOME_DEFLON: "); Serial.println(defLon);
+  Serial.print("HOME_DEFLAT: "); Serial.println(defLat);
 }

--- a/futuriumSDNoAp.ino
+++ b/futuriumSDNoAp.ino
@@ -22,6 +22,19 @@ void setup()
   initUltrasonic();
   initGPS();
   initSD();
+#ifdef DEBUG_ENABLED
+  Serial.print("try to read configuration from ");
+  Serial.println(confFile);
+#endif
+  bool ret = readConfiguration(confFile);
+#ifdef DEBUG_ENABLED
+  if (ret) {
+    Serial.println("OK");
+  } else {
+    Serial.println("not found");
+  }
+  dumpConfiguration();
+#endif
   //checkForFiles();
   //resetSD();
   rgb_led_1.begin();
@@ -91,7 +104,7 @@ void loop()
       {
         showRed();
 #ifdef DEBUG_ENABLED
-        Serial.println(F("No fix"));
+        //Serial.println(F("No fix"));
 #endif
       }
       else if (fixType == 1)

--- a/geoFenceHelper.ino
+++ b/geoFenceHelper.ino
@@ -1,0 +1,25 @@
+// Copyright (c) 1970-2003, Wm. Randolph Franklin
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimers.
+// Redistributions in binary form must reproduce the above copyright notice in the documentation and/or other materials provided with the distribution.
+// The name of W. Randolph Franklin may not be used to endorse or promote products derived from this Software without specific prior written permission.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html
+// https://www.baeldung.com/cs/geofencing-point-inside-polygon
+
+#include <stdbool.h>
+
+bool pnpoly(int nvert, float *vertx, float *verty, float testx, float testy)
+{
+  int i, j;
+  bool c = false;
+  for (i = 0, j = nvert-1; i < nvert; j = i++) {
+    if ( ((verty[i]>testy) != (verty[j]>testy)) &&
+	 (testx < (vertx[j]-vertx[i]) * (testy-verty[i]) / (verty[j]-verty[i]) + vertx[i]) )
+       c = !c;
+  }
+  return c;
+}

--- a/geoFenceHelper.ino
+++ b/geoFenceHelper.ino
@@ -12,7 +12,7 @@
 
 #include <stdbool.h>
 
-bool pnpoly(int nvert, float *vertx, float *verty, float testx, float testy)
+bool pnpoly(int nvert, double *vertx, double *verty, double testx, double testy)
 {
   int i, j;
   bool c = false;

--- a/variables/ids.h
+++ b/variables/ids.h
@@ -1,3 +1,5 @@
+char *confFile="BIKE.CFG";
+
 /** Ändere die ID's der Sensoren hier
  * Sensor IDs können über die API abgefragt werden 
  * https://api.opensensemap.org/boxes/[:senseBoxID]
@@ -5,17 +7,17 @@
 
 // senseBox ID
 // example : const char SENSEBOX_ID[] = "615f292bc031ff001b117192";
-const char SENSEBOX_ID[] = "";
+char *SENSEBOX_ID = "undef";
 
 // Sensor ID's
 // example : char tempID[] = "615f292bc031ff001b11719b";
-char tempID[] = "";
-char humiID[] = "";
-char distLeftID[] = "";
-char distRightID[] = "";
-char pm10ID[] = "";
-char pm25ID[] = "";
-char accXID[] = "";
-char accYID[] = "";
-char accZID[] = "";
-char speedID[] = "";
+char *tempID = "undef";
+char *humiID = "undef";
+char *distLeftID = "undef";
+char *distRightID = "undef";
+char *pm10ID = "undef";
+char *pm25ID = "undef";
+char *accXID = "undef";
+char *accYID = "undef";
+char *accZID = "undef";
+char *speedID = "undef";

--- a/variables/network.h
+++ b/variables/network.h
@@ -6,7 +6,5 @@
 * const char *pass = "superSafePassword2021";
 */
 
-const char *ssid = "";
-const char *pass = "";
-
-
+char *ssid = "undef";
+char *pass = "undef";

--- a/variables/variables.h
+++ b/variables/variables.h
@@ -22,6 +22,7 @@
 #include <avr/dtostrf.h>
 #include <Adafruit_NeoPixel.h>
 #include <SD.h>
+#include <SDConfig.h>
 // Load other variable files
 #include "ids.h"
 // build id arrays
@@ -105,4 +106,28 @@ double accX;
 double accY;
 double accZ;
 
+// forward declarations
+void initBMX(void);
+void initUltrasonic(void);
+void initGPS(void);
+void initSD(void);
+bool readConfiguration(char* confFile);
+void dumpConfiguration(void);
+bool isGPSvalid(void);
+void getAccAmplitudes(double*, double*, double*);
+void setTimestamp(void);
+void setGPS(void);
+void showGreen(void);
+void handleLeft(void);
+void handleRight(void);
+void checkStandby(bool *standby);
+void writeToSD(char *data, char *fileName);
+void resetSD(void);
+bool sdisempty(void);
+void getMeasurements(void);
+void connectToWifi(void);
+bool submitValues(void);
+void showRed(void);
+void showBlue(void);
+void showGreen(void);
 #endif

--- a/variables/variables.h
+++ b/variables/variables.h
@@ -105,6 +105,13 @@ double sumAccX;
 double accX;
 double accY;
 double accZ;
+// variables for geofence
+double minLon;
+double maxLon;
+double minLat;
+double maxLat;
+double defLon;
+double defLat;
 
 // forward declarations
 void initBMX(void);
@@ -130,4 +137,5 @@ bool submitValues(void);
 void showRed(void);
 void showBlue(void);
 void showGreen(void);
+bool pnpoly(int nvert, double *vertx, double *verty, double testx, double testy);
 #endif


### PR DESCRIPTION
A reverse [geofencing](https://de.wikipedia.org/wiki/Geofencing) can be set up in the 'BIKE.CFG'. This allows you to 'hide' your home address. When coordinates are recorded in the defined rectangle, they are rewritten to a fixed coordinate (e.g. a park). 

Such a rectangle can be easily determined on [Openstreetmap](https://www.openstreetmap.org/export). In this example, the default coordinate is then in Sprengelpark. The function is only active if the default coordinate `HOME_(DEFLON|DEFLAT)` is set.
